### PR TITLE
return original release body if failure for any reason

### DIFF
--- a/internal/mapping/mapping.go
+++ b/internal/mapping/mapping.go
@@ -46,7 +46,7 @@ func ModifyReleaseBody(releaseBody *string, filePath string) (*string, error) {
 	// Load handle map from file
 	handleMap, err := loadHandleMap(filePath)
 	if err != nil {
-		return nil, err
+		return releaseBody, err //return the original release body if an error occurs
 	}
 
 	// Replace old handles with new handles

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -29,7 +29,6 @@ func SyncReleases() {
 		if err != nil {
 			pterm.Error.Printf("Error modifying release body: %v", err)
 		}
-
 		// Create release api call
 		newRelease, err := api.CreateRelease(release)
 		if err != nil {


### PR DESCRIPTION
The changes ensure that the original release body is returned in case of an error, and an unnecessary line of code is removed for simplification.