### PR TITLE
Feat: skips existing releases, adds source timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.tar.gz
 *.zip
 *.json
+/tmp
 
 # Test binary, built with `go test -c`
 *.test

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -176,7 +176,11 @@ func CreateRelease(release *github.RepositoryRelease) (*github.RepositoryRelease
 	ctx := context.WithValue(context.Background(), github.SleepUntilPrimaryRateLimitResetWhenRateLimited, true)
 	newRelease, _, err := client.Repositories.CreateRelease(ctx, viper.Get("TARGET_ORGANIZATION").(string), viper.Get("REPOSITORY").(string), release)
 	if err != nil {
-		return nil, err
+		if strings.Contains(err.Error(), "already_exists") {
+			return nil, fmt.Errorf("release already exists: %v", release.GetName())
+		} else {
+			return nil, err
+		}
 	}
 
 	return newRelease, nil

--- a/internal/mapping/mapping.go
+++ b/internal/mapping/mapping.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/go-github/v62/github"
 	"github.com/spf13/viper"
 )
 
@@ -55,4 +56,19 @@ func ModifyReleaseBody(releaseBody *string, filePath string) (*string, error) {
 	}
 
 	return &updatedReleaseBody, nil
+}
+
+func AddSourceTimeStamps(release *github.RepositoryRelease) (*github.RepositoryRelease, error) {
+	releaseBody := *release.Body
+
+	// Format the timestamps
+	createdAt := release.CreatedAt.Format("January 2, 2006 at 15:04:05 CST")
+	publishedAt := release.PublishedAt.Format("January 2, 2006 at 15:04:05 CST")
+
+	// Add source timestamps to release body
+	releaseBody = releaseBody + "\n\n" + ">Release Originally Created on: " + createdAt + "\n" + "> Release Originally Published on: " + publishedAt
+
+	release.Body = &releaseBody
+
+	return release, nil
 }

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -9,16 +9,17 @@ import (
 
 func SyncReleases() {
 	// Get all releases from source repository
-	fetchReleasesSpinner, _ := pterm.DefaultSpinner.Start("Fetching releases from repository...")
+	fetchReleasesSpinner, _ := pterm.DefaultSpinner.Start("Fetching releases from repository: ", viper.GetString("REPOSITORY"))
 	releases, err := api.GetSourceRepositoryReleases()
 	if err != nil {
 		pterm.Error.Printf("Error getting releases: %v", err)
 		fetchReleasesSpinner.Fail()
 	}
+	fetchReleasesSpinner.UpdateText("Releases fetched successfully!")
 	fetchReleasesSpinner.Success()
 
 	// Create releases in target repository
-	createReleasesSpinner, _ := pterm.DefaultSpinner.Start("Creating releases in target repository...")
+	createReleasesSpinner, _ := pterm.DefaultSpinner.Start("Creating releases in target repository...", viper.GetString("REPOSITORY"))
 
 	//loop through each release and create it in the target repository
 	for _, release := range releases {
@@ -35,7 +36,6 @@ func SyncReleases() {
 			createReleasesSpinner.Fail()
 			pterm.Fatal.Printf("Error creating release: %v", err)
 		}
-		createReleasesSpinner.UpdateText("Downloading assets...")
 		// Download assets from source repository and upload to target repository
 		for _, asset := range release.Assets {
 


### PR DESCRIPTION
This pull request primarily involves changes to improve error handling and provide more informative logging in the process of synchronizing GitHub releases. The key changes include the addition of a new function to add timestamps to release bodies, improved error handling for cases where a release already exists, and enhancements to the logging messages.

Enhancements to the release migration process:

* [`internal/mapping/mapping.go`](diffhunk://#diff-6fcd2b018fdf03ed504555ca0b169e6bfc05812b4328dbf64cf622e512fd127fR60-R74): A new function `AddSourceTimeStamps` was added to append source timestamps to the release body. This function formats the `CreatedAt` and `PublishedAt` timestamps and adds them to the release body.

Improvements to error handling:

* [`internal/api/api.go`](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R179-R184): The `CreateRelease` function was modified to handle the case where a release already exists. It now returns a specific error message in this case.
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL12-R49): The release creation process was updated to handle the case where a release already exists. It now prints an info message and skips to the next release instead of failing.

User feedback enhancements:

* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befL12-R49): The feedback messages during the synchronization process were improved. The spinner text now includes the repository name and provides feedback when the releases have been fetched successfully. Error messages were also updated to provide more specific feedback.

Additional changes:

* `internal/mapping/mapping.go` and `pkg/sync/sync.go`: The `strings` package was imported to handle string operations. [[1]](diffhunk://#diff-6fcd2b018fdf03ed504555ca0b169e6bfc05812b4328dbf64cf622e512fd127fR8) [[2]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR4-R5)