### PR TITLE
Update release workflow for gh-extension-precompile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
-      - uses: cli/gh-extension-precompile@v1
+      - uses: cli/gh-extension-precompile@561b19deda1228a0edf856c3325df87416f8c9bd #v2.0.0
         with:
-          go_version: 1.21
+          go_version_file: go.mod


### PR DESCRIPTION
Updated GitHub Actions workflow to use new version of gh-extension-precompile and changed go_version input to go_version_file.

### Workflow updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L13-R15): Updated the `cli/gh-extension-precompile` action to version `v2.0.0` (commit `561b19deda1228a0edf856c3325df87416f8c9bd`) and replaced the `go_version` input with `go_version_file` pointing to `go.mod` for improved version management.