### PR TITLE
Add release drafter configuration and pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+<!--
+## Release Drafter
+
+This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:
+
+- `major` label will be a major version
+- `minor` or `enhancement` will bump it to a minor version
+- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
+-->
+
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
+
+## Checklist
+
+<!-- - [ ] Issue linked if existing -->
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] Add a label to the pull request that indicates the type of change (e.g., `major`, `minor`, `patch`, `enhancement`, `bug`)
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests
+
+## Additional Context
+
+Add any other context or screenshots about the pull request here.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER) 🚢'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter Update
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces Release Drafter configuration and guidance to the repository. The main goal is to automate and standardize the release process, including versioning and changelog generation, as well as to provide contributors with clear instructions for labeling and documenting pull requests.

**Release Automation and Configuration:**

* Added `.github/release-drafter.yml` with versioning rules, change categories, and a release note template to automate and standardize release notes and version bumps.
* Introduced `.github/workflows/release-drafter.yml` GitHub Actions workflow to automatically update the release draft on pushes to `main`.

**Contribution Process Improvements:**

* Updated `.github/pull_request_template.md` to include instructions for labeling pull requests, a checklist for contributors, and context on Release Drafter usage.