### PR TITLE
Update filename generation to use OUTPUT_FILE prefix

### DIFF
--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -19,8 +19,11 @@ func CreateJSONs() {
 		pterm.Fatal.Printf("Error getting releases: %v", err)
 	}
 	filePrefix := viper.GetString("OUTPUT_FILE")
-	if filePrefix != "" && filePrefix[len(filePrefix)-1] != '-' && filePrefix[len(filePrefix)-1] != '/' {
-		filePrefix = filePrefix + "-"
+	if filePrefix != "" {
+		lastChar := filePrefix[len(filePrefix)-1]
+		if lastChar != '-' && lastChar != '/' {
+			filePrefix = filePrefix + "-"
+		}
 	}
 	for index, release := range releases {
 		filename := filePrefix + "release-" + fmt.Sprint(index) + ".json"

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -19,7 +19,8 @@ func CreateJSONs() {
 		pterm.Fatal.Printf("Error getting releases: %v", err)
 	}
 	for index, release := range releases {
-		filename := "release-" + fmt.Sprint(index) + ".json"
+		filePrefix := viper.GetString("OUTPUT_FILE")
+		filename := filePrefix + "release-" + fmt.Sprint(index) + ".json"
 		err := files.CreateJSON(release, filename)
 		if err != nil {
 			pterm.Fatal.Printf("Error creating JSON: %v", err)

--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -18,8 +18,11 @@ func CreateJSONs() {
 	if err != nil {
 		pterm.Fatal.Printf("Error getting releases: %v", err)
 	}
+	filePrefix := viper.GetString("OUTPUT_FILE")
+	if filePrefix != "" && filePrefix[len(filePrefix)-1] != '-' && filePrefix[len(filePrefix)-1] != '/' {
+		filePrefix = filePrefix + "-"
+	}
 	for index, release := range releases {
-		filePrefix := viper.GetString("OUTPUT_FILE")
 		filename := filePrefix + "release-" + fmt.Sprint(index) + ".json"
 		err := files.CreateJSON(release, filename)
 		if err != nil {


### PR DESCRIPTION
Small fix for using file prefixes.

## Description

Ensures the file output uses the prefix configured via `OUTPUT_FILE`. The `OUTPUT_FILE` lookup is now performed once before iterating over releases, and a separator (`-`) is automatically appended to the prefix if it does not already end with `-` or `/`, preventing malformed filenames when a prefix is provided.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Add a label to the pull request that indicates the type of change (e.g., `major`, `minor`, `patch`, `enhancement`, `bug`)
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests

## Additional Context

Add any other context or screenshots about the pull request here.

<!-- START COPILOT CODING AGENT TIPS -->
---

⚡ Quickly spin up Copilot coding agent tasks from anywhere on your macOS or Windows machine with [Raycast](https://gh.io/cca-raycast-docs).
